### PR TITLE
Installing Metacall-deploy locally if it's not installed

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,1 @@
+making icons work for darkmode and icons for light mode

--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -38,7 +38,7 @@ export class InstallCheck {
     } catch (error: any) {
       vscode.window.showWarningMessage('Metacall is not installed', 'Install Metacall').then((selection) => {
         if (selection === 'Install Metacall') {
-          vscode.env.openExternal(vscode.Uri.parse('https://github.com/metacall/deploy#readme'));
+          vscode.commands.executeCommand('metacall.installCLI');
         }
       });
       return false;

--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -1,8 +1,7 @@
-import path from "path";
+import * as path from "path";
 import { extVars } from "../statics/extension.variables";
 import * as vscode from "vscode";
 import * as child_process from 'child_process';
-
 export function getIconPath(iconName: string): string {
   return path.join(getResourcesPath(), iconName);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
 	"compilerOptions": {
 		"module": "commonjs",
 		"target": "ES2020",
+		"allowSyntheticDefaultImports": true,
 		"lib": [
 			"ES2020"
 		],


### PR DESCRIPTION
That's more better than opening external link for the user. there is no need for that while we can install it for him.