### PR TITLE
Feature: Adding project name option in the deployment process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 node_modules
 .vscode-test/
 *.vsix
+TODO

--- a/TODO
+++ b/TODO
@@ -1,3 +1,0 @@
-making icons work for darkmode and icons for light mode
-
-Not valid url bug while trying to deploy using url

--- a/TODO
+++ b/TODO
@@ -1,1 +1,3 @@
 making icons work for darkmode and icons for light mode
+
+Not valid url bug while trying to deploy using url

--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -33,7 +33,7 @@ export class InstallCheck {
         .toString()
         .trim();
       if (/^\d+\.\d+\.\d+$/.test(version)) {
-        vscode.window.showInformationMessage("Metacall is installed!");
+        // It's ok. no need for showing info message
         return true;
       } else {
         return false;

--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import { extVars } from "../statics/extension.variables";
 import * as vscode from "vscode";
-import * as child_process from 'child_process';
+import * as child_process from "child_process";
 export function getIconPath(iconName: string): string {
   return path.join(getResourcesPath(), iconName);
 }
@@ -28,25 +28,30 @@ export const createNewTask = (
 export class InstallCheck {
   public static async checkInstall(): Promise<boolean> {
     try {
-      const version = child_process.execSync('metacall-deploy --version').toString().trim();
+      const version = child_process
+        .execSync("metacall-deploy --version")
+        .toString()
+        .trim();
       if (/^\d+\.\d+\.\d+$/.test(version)) {
-        vscode.window.showInformationMessage('Metacall is installed!');
+        vscode.window.showInformationMessage("Metacall is installed!");
         return true;
       } else {
         return false;
       }
     } catch (error: any) {
-      vscode.window.showWarningMessage('Metacall is not installed', 'Install Metacall').then((selection) => {
-        if (selection === 'Install Metacall') {
-          vscode.commands.executeCommand('metacall.installCLI');
-        }
-      });
+      vscode.window
+        .showWarningMessage("Metacall is not installed", "Install Metacall")
+        .then((selection) => {
+          if (selection === "Install Metacall") {
+            vscode.commands.executeCommand("metacall.installCLI");
+          }
+        });
       return false;
     }
   }
 }
 
-function isValidUrl(url: string): boolean {
+export function isValidUrl(url: string): boolean {
   try {
     new URL(url);
     return true;
@@ -55,20 +60,31 @@ function isValidUrl(url: string): boolean {
   }
 }
 
-export async function showInputBox(placeHolder: string) {
+export function isValidProjectName(name: string): boolean {
+  return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name);
+}
+
+export async function showInputBox(
+  placeHolder: string,
+  errorMessage: string,
+  validateInput: Function
+) {
   const result = await vscode.window.showInputBox({
     value: "",
     placeHolder: placeHolder,
     validateInput: (text) => {
-      if (!isValidUrl(text)) {
-        return "Invalid URL";
+      if (!validateInput(text)) {
+        return errorMessage;
       }
     },
   });
   return result;
 }
 
-export async function chooseInput(placeHolder: string, ...choices: string[]) {
+export async function multipleInputs(
+  placeHolder: string,
+  ...choices: string[]
+) {
   let i = 0;
   const result = await vscode.window.showQuickPick(choices, {
     placeHolder: placeHolder,


### PR DESCRIPTION
## Additions
- ### Adding project name options throw the deployment process. 2 options:
>- Use the default name (The workspace folder name) for the deployment.
>- Enter new Name with some restrictions on it (No spaces - first or last char shouldn't be (-) - no uppercase letters).

- ### Adding validation if there is no open workspace folder.

## [Testing Demo Video](https://drive.google.com/file/d/1t4r5erPr0KnJGidJ63Oyu6-VpgSBk6xC/view?usp=share_link)

![image](https://user-images.githubusercontent.com/77173710/232227672-66f62561-cc5a-4a8c-91df-5e299b60604c.png)
