### PR TITLE
fix: correct activation event, remove helloWorld command, fix memory leak and delete task type

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "Snippets"
   ],
   "activationEvents": [
-    "onCommand:MetaCall.helloWorld"
+    "onStartupFinished"
   ],
   "main": "./dist/extension.js",
   "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,8 +5,6 @@ import { registerWebViews } from "./registeration/register.web.views";
 import { registerCommands } from "./registeration/register.commands";
 
 export async function activate(context: vscode.ExtensionContext) {
-  vscode.window.showInformationMessage("Hello World from metacall!");
-
   // checking cli installation
   vscode.commands.executeCommand("metacall.checkInstall");
 

--- a/src/registeration/register.commands.ts
+++ b/src/registeration/register.commands.ts
@@ -12,14 +12,6 @@ import { OpenUrlTreeItem } from "../views/tree.views/OpenUrlTreeItem";
 import { GenericTreeItem } from "@microsoft/vscode-azext-utils";
 
 export const registerCommands = (context: vscode.ExtensionContext) => {
-  const helloWorldCommand = vscode.commands.registerCommand(
-    "metacall.helloWorld",
-    () => {
-      vscode.window.showInformationMessage(
-        "Hello World from metacall! Let's deploy...🚀"
-      );
-    }
-  );
 
   const checkInstallCommand = vscode.commands.registerCommand(
     "metacall.checkInstall",
@@ -219,7 +211,7 @@ export const registerCommands = (context: vscode.ExtensionContext) => {
       const deleteTask: vscode.Task = createNewTask(
         "shell.Delete",
         "Delete Deployment Terminal",
-        "metacall.delete",
+        "metacall.deleteDeployment",
         `metacall-deploy --delete`
       );
       try {
@@ -231,7 +223,7 @@ export const registerCommands = (context: vscode.ExtensionContext) => {
   );
 
   context.subscriptions.push(
-    helloWorldCommand,
+    checkInstallCommand,
     helpCommand,
     deployCommand,
     logoutCommand,


### PR DESCRIPTION
## Summary
Found and fixed 5 issues while exploring the codebase:

1. **Wrong activation event** — `onCommand:MetaCall.helloWorld` meant the extension only activated when helloWorld was called, so real commands like `metacall.deploy` never worked on startup. Fixed to `onStartupFinished`.

2. **Removed helloWorldCommand** — leftover template command that served no real purpose.

3. **Memory leak** — `checkInstallCommand` was registered but never added to `context.subscriptions.push()`, meaning it was never disposed on deactivation.

4. **Wrong task type in deleteCommand** — task was using `"metacall.delete"` instead of `"metacall.deleteDeployment"` to match the command registration.

5. **Removed Hello World template message** — leftover `showInformationMessage("Hello World from metacall!")` was showing on every extension activation.

## Type of change
- [x] Bug fix

## Checklist
- [x] I have read the contributing guidelines
- [x] My changes generate no new warnings