### PR TITLE
Use local VS Code executable in tests

### DIFF
--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -13,7 +13,13 @@ async function main() {
 		const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
 		// Download VS Code, unzip it and run the integration test
-		await runTests({ extensionDevelopmentPath, extensionTestsPath });
+		const vscodeExecutablePath =
+			process.env.VSCODE_EXECUTABLE || process.env.VSCODE_EXECUTABLE_PATH;
+		await runTests({
+			extensionDevelopmentPath,
+			extensionTestsPath,
+			...(vscodeExecutablePath ? { vscodeExecutablePath } : {})
+		});
 	} catch (err) {
 		console.error('Failed to run tests');
 		process.exit(1);

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -12,7 +12,7 @@ async function main() {
 		// Passed to --extensionTestsPath
 		const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
-		// Download VS Code, unzip it and run the integration test
+		// Use a provided VS Code executable (via env vars) or download VS Code and run the integration test
 		const vscodeExecutablePath =
 			process.env.VSCODE_EXECUTABLE || process.env.VSCODE_EXECUTABLE_PATH;
 		await runTests({


### PR DESCRIPTION
 Allow tests to use a locally installed VS Code when VSCODE_EXECUTABLE or VSCODE_EXECUTABLE_PATH is set
 `npm test` with `VSCODE_EXECUTABLE=/Applications/Visual Studio Code.app/Contents/MacOS/Electron`