### PR TITLE
ci: add GitHub Actions workflow for lint and cross-platform testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Run Lint
+        run: npm run lint
+
+  test:
+    name: Build and Test
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Run Tests (Linux)
+        if: runner.os == 'Linux'
+        run: xvfb-run -a npm test
+
+      - name: Run Tests (Non-Linux)
+        if: runner.os != 'Linux'
+        run: npm test


### PR DESCRIPTION
## Summary
Adds a GitHub Actions CI workflow as requested. The extension had no automated testing or CI setup — this PR adds it.

## What this adds

**Lint job:**
- Runs ESLint on every push and PR
- Catches code style issues early

**Build and Test job:**
- Runs on ubuntu-latest, macos-latest and windows-latest
- Uses Node.js 18
- On Linux: uses xvfb-run for headless VS Code display (required for @vscode/test-electron)
- On macOS and Windows: runs npm test directly
- Tests the existing Mocha test suite via @vscode/test-electron

## Research
VS Code extension testing requires a real display on Linux since VS Code spawns an actual window. xvfb-run provides a virtual framebuffer for this. This is the approach used by VS Code's own extension samples and microsoft/vscode-extension-samples.

## Type of change
- [x] Chore / CI

## Checklist
- [x] I have read the contributing guidelines
- [x] My changes generate no new warnings