### PR TITLE
refactor: replace @microsoft/vscode-azext-utils with native VS Code APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
       "name": "metacall",
       "version": "0.0.1",
       "dependencies": {
-        "@metacall/protocol": "^0.1.21",
-        "@microsoft/vscode-azext-utils": "^1.0.0",
+        "@metacall/protocol": "^0.1.26",
         "@vscode/codicons": "^0.0.32"
       },
       "devDependencies": {
+        "@azure/ms-rest-azure-env": "^2.0.0",
         "@types/glob": "^8.0.0",
         "@types/mocha": "^10.0.1",
         "@types/node": "16.x",
@@ -25,13 +25,19 @@
         "mocha": "^10.1.0",
         "ts-loader": "^9.4.1",
         "typescript": "^4.9.3",
-        "vscode": "^1.1.37",
         "webpack": "^5.75.0",
         "webpack-cli": "^5.0.0"
       },
       "engines": {
         "vscode": "^1.74.0"
       }
+    },
+    "node_modules/@azure/ms-rest-azure-env": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz",
+      "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -157,90 +163,17 @@
       }
     },
     "node_modules/@metacall/protocol": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@metacall/protocol/-/protocol-0.1.21.tgz",
-      "integrity": "sha512-jQoNbCX/Y+nLJT/Ff/BO6bfZrS5trotIpmkig76F7FzajVj08qa1837UMEDLYLYImzX7RE1ZU6eei3mZ11p8hw==",
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/@metacall/protocol/-/protocol-0.1.28.tgz",
+      "integrity": "sha512-7xG6ms0oAxbBQM1wRVcOTD6L8it6qjRHSG81X3sIA2WL0XXA6XD6E0TD1/w21eOl9jDsJVALNaN2JGl/YqPKLw==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@types/ignore-walk": "^4.0.0",
-        "@types/jsonwebtoken": "^8.5.8",
-        "axios": "^0.21.0",
+        "axios": "^1.13.5",
         "form-data": "^3.0.0",
         "ignore-walk": "^3.0.4",
         "jsonwebtoken": "^9.0.0"
       }
-    },
-    "node_modules/@microsoft/1ds-core-js": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.9.tgz",
-      "integrity": "sha512-3pCfM2TzHn3gU9pxHztduKcVRdb/nzruvPFfHPZD0IM0mb0h6TGo2isELF3CTMahTx50RAC51ojNIw2/7VRkOg==",
-      "dependencies": {
-        "@microsoft/applicationinsights-core-js": "2.8.10",
-        "@microsoft/applicationinsights-shims": "^2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.7"
-      }
-    },
-    "node_modules/@microsoft/1ds-post-js": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.9.tgz",
-      "integrity": "sha512-D/RtqkQ2Nr4cuoGqmhi5QTmi3cBlxehIThJ1u3BaH9H/YkLNTKEcHZRWTXy14bXheCefNHciLuadg37G2Kekcg==",
-      "dependencies": {
-        "@microsoft/1ds-core-js": "3.2.9",
-        "@microsoft/applicationinsights-shims": "^2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.7"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "2.8.10",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.10.tgz",
-      "integrity": "sha512-jQrufDW0+sV8fBhRvzIPNGiCC6dELH+Ug0DM5CfN9757TBqZJz8CSWyDjex39as8+jD0F/8HRU9QdmrVgq5vFg==",
-      "dependencies": {
-        "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.7"
-      },
-      "peerDependencies": {
-        "tslib": "*"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-shims": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.2.tgz",
-      "integrity": "sha512-PoHEgsnmcqruLNHZ/amACqdJ6YYQpED0KSRe6J7gIJTtpZC1FfFU9b1fmDKDKtFoUSrPzEh1qzO3kmRZP0betg=="
-    },
-    "node_modules/@microsoft/dynamicproto-js": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.8.tgz",
-      "integrity": "sha512-j4ZgOZRtX0LTUgKq+4tRQotgwH03HH/mLkYbcgFBBJ9XKTDc4NIGzZeam2UQMzwz+5IVN0SXexNbbsz5B0b/og=="
-    },
-    "node_modules/@microsoft/vscode-azext-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-1.1.0.tgz",
-      "integrity": "sha512-rxKCApwQBEebcY2byLm2VOT+KA7S2DyuBXyLZtBBmfN6L0a81dHZwZo8ug2CAs08POS1Ql1vzLbVa8CLeF83KA==",
-      "dependencies": {
-        "@microsoft/vscode-azureresources-api": "^2.0.2",
-        "@vscode/extension-telemetry": "^0.6.2",
-        "dayjs": "^1.11.2",
-        "escape-string-regexp": "^2.0.0",
-        "html-to-text": "^8.2.0",
-        "semver": "^7.3.7",
-        "uuid": "^9.0.0",
-        "vscode-nls": "^5.0.1",
-        "vscode-tas-client": "^0.1.47",
-        "vscode-uri": "^3.0.6"
-      }
-    },
-    "node_modules/@microsoft/vscode-azext-utils/node_modules/escape-string-regexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@microsoft/vscode-azureresources-api": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-2.0.4.tgz",
-      "integrity": "sha512-LridV1h2rCydrBzEpwy+pUIUx61GpZNwrK04G7LdlhoxHrzuM/WAoy8jXaSC/FSKSsXD1QXuE6u/YofEfsuKeg=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -275,18 +208,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@selderee/plugin-htmlparser2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.6.0.tgz",
-      "integrity": "sha512-J3jpy002TyBjd4N/p6s+s90eX42H2eRhK3SbsZuvTDv977/E8p2U3zikdiehyJja66do7FlxLomZLPlvl2/xaA==",
-      "dependencies": {
-        "domhandler": "^4.2.0",
-        "selderee": "^0.6.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -334,27 +255,11 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/ignore-walk": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/ignore-walk/-/ignore-walk-4.0.0.tgz",
-      "integrity": "sha512-T5+1xZfSpgIz7FntMveRpKdLWZhPOidwaxVjUjGjyCXsaD2cVFr4a1+qd2HPcsM9qP0XBkg4jC9NdmuD3lZeqQ==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
-    },
-    "node_modules/@types/jsonwebtoken": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz",
-      "integrity": "sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
@@ -371,7 +276,8 @@
     "node_modules/@types/node": {
       "version": "16.18.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
-      "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA=="
+      "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==",
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -423,6 +329,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.49.0.tgz",
       "integrity": "sha512-veDlZN9mUhGqU31Qiv2qEp+XrJj5fgZpJ8PW30sHU+j/8/e5ruAhLaVDAeznS7A7i4ucb/s8IozpDtt9NqCkZg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.49.0",
         "@typescript-eslint/types": "5.49.0",
@@ -576,18 +483,6 @@
       "version": "0.0.32",
       "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.32.tgz",
       "integrity": "sha512-3lgSTWhAzzWN/EPURoY4ZDBEA80OPmnaknNujA3qnI4Iu7AONWd9xF3iE4L+4prIe8E3TUnLQ4pxoaFTEEZNwg=="
-    },
-    "node_modules/@vscode/extension-telemetry": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.6.2.tgz",
-      "integrity": "sha512-yb/wxLuaaCRcBAZtDCjNYSisAXz3FWsSqAha5nhHcYxx2ZPdQdWuZqVXGKq0ZpHVndBWWtK6XqtpCN2/HB4S1w==",
-      "dependencies": {
-        "@microsoft/1ds-core-js": "^3.2.3",
-        "@microsoft/1ds-post-js": "^3.2.3"
-      },
-      "engines": {
-        "vscode": "^1.60.0"
-      }
     },
     "node_modules/@vscode/test-electron": {
       "version": "2.2.2",
@@ -811,6 +706,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
       "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -853,6 +749,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -940,11 +837,30 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/balanced-match": {
@@ -1031,6 +947,7 @@
           "url": "https://tidelift.com/funding/github/npm/browserslist"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001400",
         "electron-to-chromium": "^1.4.251",
@@ -1071,6 +988,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.2.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -1249,7 +1179,8 @@
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1275,11 +1206,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/dayjs": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
-      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -1316,14 +1242,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1353,11 +1271,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/discontinuous-range": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
-    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1370,55 +1283,18 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
       "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ]
-    },
-    "node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
       },
       "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
+        "node": ">= 0.4"
       }
     },
     "node_modules/duplexer2": {
@@ -1463,14 +1339,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/envinfo": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
@@ -1483,25 +1351,55 @@
         "node": ">=4"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
       "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
       "dev": true
     },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
-    },
-    "node_modules/es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
-      "dev": true,
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
       "dependencies": {
-        "es6-promise": "^4.0.3"
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -1530,6 +1428,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
       "integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.4.1",
         "@humanwhocodes/config-array": "^0.11.8",
@@ -1871,15 +1770,16 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -1970,10 +1870,13 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -1982,6 +1885,43 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -2077,6 +2017,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -2088,15 +2040,6 @@
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
-    },
-    "node_modules/growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.x"
-      }
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -2119,49 +2062,52 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
       "bin": {
         "he": "bin/he"
-      }
-    },
-    "node_modules/html-to-text": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-8.2.1.tgz",
-      "integrity": "sha512-aN/3JvAk8qFsWVeE9InWAWueLXrbkoVZy0TkzaGhoRBC2gCFEeRLDDJN3/ijIGHohy6H+SZzUQWN/hcYtaPK8w==",
-      "dependencies": {
-        "@selderee/plugin-htmlparser2": "^0.6.0",
-        "deepmerge": "^4.2.2",
-        "he": "^1.2.0",
-        "htmlparser2": "^6.1.0",
-        "minimist": "^1.2.6",
-        "selderee": "^0.6.0"
-      },
-      "bin": {
-        "html-to-text": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10.23.2"
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -2596,6 +2542,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -2658,6 +2613,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
       "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2788,11 +2744,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/moo": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -2821,27 +2772,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
-    },
-    "node_modules/nearley": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-      "dependencies": {
-        "commander": "^2.19.0",
-        "moo": "^0.5.0",
-        "railroad-diagrams": "^1.0.0",
-        "randexp": "0.4.6"
-      },
-      "bin": {
-        "nearley-railroad": "bin/nearley-railroad.js",
-        "nearley-test": "bin/nearley-test.js",
-        "nearley-unparse": "bin/nearley-unparse.js",
-        "nearleyc": "bin/nearleyc.js"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://nearley.js.org/#give-to-nearley"
-      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -2939,18 +2869,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/parseley": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.7.0.tgz",
-      "integrity": "sha512-xyOytsdDu077M3/46Am+2cGXEKM9U9QclBDv7fimY7e+BBlxh2JcBp2mgNsmkyA9uvgyTjVzDi7cP1v4hcFxbw==",
-      "dependencies": {
-        "moo": "^0.5.1",
-        "nearley": "^2.20.1"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/path-exists": {
@@ -3092,6 +3010,12 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -3120,23 +3044,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/railroad-diagrams": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
-    },
-    "node_modules/randexp": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-      "dependencies": {
-        "discontinuous-range": "1.0.0",
-        "ret": "~0.1.10"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -3260,14 +3167,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/ret": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -3371,17 +3270,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/selderee": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.6.0.tgz",
-      "integrity": "sha512-ibqWGV5aChDvfVdqNYuaJP/HnVBhlRGSRrlbttmlMpHcLuTqqbMH36QkSs9GEgj5M88JDYLI8eyP94JaQ8xRlg==",
-      "dependencies": {
-        "parseley": "^0.7.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/semver": {
@@ -3560,22 +3448,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tas-client": {
-      "version": "0.1.58",
-      "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.58.tgz",
-      "integrity": "sha512-fOWii4wQXuo9Zl0oXgvjBzZWzKc5MmUR6XQWX93WU2c1SaP1plPo/zvXP8kpbZ9fvegFOHdapszYqMTRq/SRtg==",
-      "dependencies": {
-        "axios": "^0.26.1"
-      }
-    },
-    "node_modules/tas-client/node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.8"
-      }
-    },
     "node_modules/terser": {
       "version": "5.16.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
@@ -3677,7 +3549,9 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -3723,6 +3597,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3790,296 +3665,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
-    "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/vscode": {
-      "version": "1.1.37",
-      "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.37.tgz",
-      "integrity": "sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==",
-      "deprecated": "This package is deprecated in favor of @types/vscode and vscode-test. For more information please read: https://code.visualstudio.com/updates/v1_36#_splitting-vscode-package-into-typesvscode-and-vscodetest",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.2",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "mocha": "^5.2.0",
-        "semver": "^5.4.1",
-        "source-map-support": "^0.5.0",
-        "vscode-test": "^0.4.1"
-      },
-      "bin": {
-        "vscode-install": "bin/install"
-      },
-      "engines": {
-        "node": ">=8.9.3"
-      }
-    },
-    "node_modules/vscode-nls": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
-      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng=="
-    },
-    "node_modules/vscode-tas-client": {
-      "version": "0.1.63",
-      "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.63.tgz",
-      "integrity": "sha512-TY5TPyibzi6rNmuUB7eRVqpzLzNfQYrrIl/0/F8ukrrbzOrKVvS31hM3urE+tbaVrnT+TMYXL16GhX57vEowhA==",
-      "dependencies": {
-        "tas-client": "0.1.58"
-      },
-      "engines": {
-        "vscode": "^1.19.1"
-      }
-    },
-    "node_modules/vscode-test": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
-      "integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
-      "deprecated": "This package has been renamed to @vscode/test-electron, please update to the new name",
-      "dev": true,
-      "dependencies": {
-        "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.9.3"
-      }
-    },
-    "node_modules/vscode-test/node_modules/agent-base": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-      "dev": true,
-      "dependencies": {
-        "es6-promisify": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/vscode-test/node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/vscode-test/node_modules/http-proxy-agent": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "4",
-        "debug": "3.1.0"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
-      }
-    },
-    "node_modules/vscode-test/node_modules/https-proxy-agent": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "^4.3.0",
-        "debug": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
-      }
-    },
-    "node_modules/vscode-test/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
-    },
-    "node_modules/vscode-uri": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
-      "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
-    },
-    "node_modules/vscode/node_modules/commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-      "dev": true
-    },
-    "node_modules/vscode/node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/vscode/node_modules/diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/vscode/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/vscode/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/vscode/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/vscode/node_modules/he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha512-z/GDPjlRMNOa2XJiB4em8wJpuuBfrFOlYKTZxtpkdr1uPdibHI8rYA3MY0KDObpVyaes0e/aunid/t88ZI2EKA==",
-      "dev": true,
-      "bin": {
-        "he": "bin/he"
-      }
-    },
-    "node_modules/vscode/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
-      "dev": true
-    },
-    "node_modules/vscode/node_modules/mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "dev": true,
-      "dependencies": {
-        "minimist": "0.0.8"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/vscode/node_modules/mocha": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
-      "dev": true,
-      "dependencies": {
-        "browser-stdout": "1.3.1",
-        "commander": "2.15.1",
-        "debug": "3.1.0",
-        "diff": "3.5.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
-        "growl": "1.10.5",
-        "he": "1.1.1",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "supports-color": "5.4.0"
-      },
-      "bin": {
-        "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/vscode/node_modules/mocha/node_modules/glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/vscode/node_modules/mocha/node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/vscode/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
-    },
-    "node_modules/vscode/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/vscode/node_modules/supports-color": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/watchpack": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -4098,6 +3683,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
       "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -4145,6 +3731,7 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.1.tgz",
       "integrity": "sha512-S3KVAyfwUqr0Mo/ur3NzIp6jnerNpo7GUO6so51mxLi1spqsA17YcMXy0WOIJtBSnj748lthxC6XLbNKh/ZC+A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "test": "node ./out/test/runTest.js"
   },
   "devDependencies": {
+    "@azure/ms-rest-azure-env": "^2.0.0",
     "@types/glob": "^8.0.0",
     "@types/mocha": "^10.0.1",
     "@types/node": "16.x",
@@ -171,13 +172,11 @@
     "mocha": "^10.1.0",
     "ts-loader": "^9.4.1",
     "typescript": "^4.9.3",
-    "vscode": "^1.1.37",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.0"
   },
   "dependencies": {
-    "@metacall/protocol": "^0.1.21",
-    "@microsoft/vscode-azext-utils": "^1.0.0",
+    "@metacall/protocol": "^0.1.26",
     "@vscode/codicons": "^0.0.32"
   }
 }

--- a/src/registeration/register.commands.ts
+++ b/src/registeration/register.commands.ts
@@ -9,7 +9,6 @@ import {
   isValidProjectName,
 } from "../utils/utilities";
 import { OpenUrlTreeItem } from "../views/tree.views/OpenUrlTreeItem";
-import { GenericTreeItem } from "@microsoft/vscode-azext-utils";
 
 export const registerCommands = (context: vscode.ExtensionContext) => {
   const helloWorldCommand = vscode.commands.registerCommand(
@@ -159,7 +158,7 @@ export const registerCommands = (context: vscode.ExtensionContext) => {
 
   const deployWithUrlCommand = vscode.commands.registerCommand(
     "metacall.deployWithRepoUrl",
-    async (item: GenericTreeItem) => {
+    async (item: vscode.TreeItem) => {
       const url: string | undefined = await showInputBox(
         "Enter the Repo URL",
         "Not valid URL",
@@ -215,7 +214,7 @@ export const registerCommands = (context: vscode.ExtensionContext) => {
 
   const deleteCommand = vscode.commands.registerCommand(
     "metacall.deleteDeployment",
-    async (item: GenericTreeItem) => {
+    async (item: vscode.TreeItem) => {
       const deleteTask: vscode.Task = createNewTask(
         "shell.Delete",
         "Delete Deployment Terminal",

--- a/src/registeration/register.tree.views.ts
+++ b/src/registeration/register.tree.views.ts
@@ -1,25 +1,19 @@
 import * as vscode from "vscode";
 import { HelpsTreeItem } from "../views/tree.views/Help.Feedback.Item";
-import { AzExtTreeDataProvider } from "@microsoft/vscode-azext-utils";
+import { NativeTreeDataProvider } from "../views/tree.views/NativeTreeDataProvider";
 import { HomeTreeItem } from "../views/tree.views/home.tree.item";
 
 export const registerTrees = (context: vscode.ExtensionContext) => {
-  const helpRoot = new HelpsTreeItem(undefined);
-  const helpTreeDataProvider = new AzExtTreeDataProvider(
-    helpRoot,
-    "metacall.helpView"
-  );
+  const helpRoot = new HelpsTreeItem();
+  const helpTreeDataProvider = new NativeTreeDataProvider(helpRoot);
 
   const helpTreeView = vscode.window.createTreeView(
     "metacall.helpAndFeedbackView",
     { treeDataProvider: helpTreeDataProvider, canSelectMany: false }
   );
 
-  const homeRoot = new HomeTreeItem(undefined);
-  const homeTreeDataProvider = new AzExtTreeDataProvider(
-    homeRoot,
-    "metacall.homeView"
-  );
+  const homeRoot = new HomeTreeItem();
+  const homeTreeDataProvider = new NativeTreeDataProvider(homeRoot);
 
   const homeTreeView = vscode.window.createTreeView("metacall.homeView", {
     treeDataProvider: homeTreeDataProvider,

--- a/src/views/tree.views/Help.Feedback.Item.ts
+++ b/src/views/tree.views/Help.Feedback.Item.ts
@@ -5,22 +5,23 @@ import {
   REPORT_ISSUE_URL,
   WEBSITE_URL,
 } from "../../statics/urls";
-import {
-  AzExtParentTreeItem,
-  AzExtTreeItem,
-  GenericTreeItem,
-} from "@microsoft/vscode-azext-utils";
+import * as vscode from "vscode";
 import { l10n } from "vscode";
 import { getIconPath } from "../../utils/utilities";
 import { OpenUrlTreeItem } from "./OpenUrlTreeItem";
 
-export class HelpsTreeItem extends AzExtParentTreeItem {
+export class HelpsTreeItem extends vscode.TreeItem {
   public label: string = "Help and Feedback";
   public contextValue: string = "help";
 
-  private values?: GenericTreeItem[];
+  constructor() {
+    super("Help and Feedback", vscode.TreeItemCollapsibleState.Expanded);
+    this.contextValue = "help";
+  }
 
-  public async loadMoreChildrenImpl(): Promise<AzExtTreeItem[]> {
+  private values?: vscode.TreeItem[];
+
+  public async getChildren(): Promise<vscode.TreeItem[]> {
     return (
       this.values ??
       (this.values = [
@@ -35,45 +36,29 @@ export class HelpsTreeItem extends AzExtParentTreeItem {
     );
   }
 
-  public hasMoreChildrenImpl(): boolean {
-    return false;
-  }
-
-  public compareChildrenImpl(
-    item1: AzExtTreeItem,
-    item2: AzExtTreeItem
-  ): number {
-    if (!item1 || !item1.id) {
-      return -1;
-    }
-    if (!item2 || !item2.id) {
-      return 1;
-    }
-    return item1?.id.localeCompare(item2?.id);
-  }
-
-  private get installMetacallCLITreeItem(): AzExtTreeItem {
-    const node = new GenericTreeItem(this, {
-      label: l10n.t("Install Metacall Deploy CLI"),
-      contextValue: "Install Metacall Deploy CLI",
-      commandId: "metacall.installCLI",
-      iconPath: getIconPath("metacall.png"),
-      includeInTreeItemPicker: true,
-    });
-
+  private get installMetacallCLITreeItem(): vscode.TreeItem {
+    const node = new vscode.TreeItem(
+      l10n.t("Install Metacall Deploy CLI"),
+      vscode.TreeItemCollapsibleState.None
+    );
+    node.contextValue = "Install Metacall Deploy CLI";
+    node.command = {
+      command: "metacall.installCLI",
+      title: l10n.t("Install Metacall Deploy CLI"),
+    };
+    node.iconPath = getIconPath("metacall.png");
     node.id = "0";
 
     return node;
   }
 
-  private get watchVideosTreeItem(): AzExtTreeItem {
+  private get watchVideosTreeItem(): vscode.TreeItem {
     const node = new OpenUrlTreeItem(
-      this,
       l10n.t("Watch Metacall Faas Tutorial"),
       TUTORIAL_URL,
       {
-        dark: getIconPath("/dark/play-circle.svg"),
-        light: getIconPath("/light/play-circle.svg"),
+        dark: vscode.Uri.file(getIconPath("/dark/play-circle.svg")),
+        light: vscode.Uri.file(getIconPath("/light/play-circle.svg")),
       }
     );
 
@@ -82,14 +67,13 @@ export class HelpsTreeItem extends AzExtParentTreeItem {
     return node;
   }
 
-  private get readDocumentationTreeItem(): AzExtTreeItem {
+  private get readDocumentationTreeItem(): vscode.TreeItem {
     const node = new OpenUrlTreeItem(
-      this,
       l10n.t("Read Metacall CLI Documentation"),
       CLI_URL,
       {
-        dark: getIconPath("dark/book.svg"),
-        light: getIconPath("light/book.svg"),
+        dark: vscode.Uri.file(getIconPath("dark/book.svg")),
+        light: vscode.Uri.file(getIconPath("light/book.svg")),
       }
     );
 
@@ -98,14 +82,13 @@ export class HelpsTreeItem extends AzExtParentTreeItem {
     return node;
   }
 
-  private get openWebsiteTreeItem(): AzExtTreeItem {
+  private get openWebsiteTreeItem(): vscode.TreeItem {
     const node = new OpenUrlTreeItem(
-      this,
       l10n.t("Open Metacall Website"),
       WEBSITE_URL,
       {
-        dark: getIconPath("dark/browser.svg"),
-        light: getIconPath("light/browser.svg"),
+        dark: vscode.Uri.file(getIconPath("dark/browser.svg")),
+        light: vscode.Uri.file(getIconPath("light/browser.svg")),
       }
     );
 
@@ -114,27 +97,29 @@ export class HelpsTreeItem extends AzExtParentTreeItem {
     return node;
   }
 
-  private get cliHelpTreeItem(): AzExtTreeItem {
-    const node = new GenericTreeItem(this, {
-      label: l10n.t("Metacall CLI Help"),
-      contextValue: "Metacall CLI Help",
-      commandId: "metacall.help",
-      iconPath: {
-        dark: getIconPath("dark/question.svg"),
-        light: getIconPath("light/question.svg"),
-      },
-      includeInTreeItemPicker: true,
-    });
-
+  private get cliHelpTreeItem(): vscode.TreeItem {
+    const node = new vscode.TreeItem(
+      l10n.t("Metacall CLI Help"),
+      vscode.TreeItemCollapsibleState.None
+    );
+    node.contextValue = "Metacall CLI Help";
+    node.command = {
+      command: "metacall.help",
+      title: l10n.t("Metacall CLI Help"),
+    };
+    node.iconPath = {
+      dark: vscode.Uri.file(getIconPath("dark/question.svg")),
+      light: vscode.Uri.file(getIconPath("light/question.svg")),
+    };
     node.id = "4";
 
     return node;
   }
 
-  private get contributeTreeItem(): AzExtTreeItem {
-    const node = new OpenUrlTreeItem(this, l10n.t("Contribute"), REPO_URL, {
-      dark: getIconPath("dark/issues.svg"),
-      light: getIconPath("light/issues.svg"),
+  private get contributeTreeItem(): vscode.TreeItem {
+    const node = new OpenUrlTreeItem(l10n.t("Contribute"), REPO_URL, {
+      dark: vscode.Uri.file(getIconPath("dark/issues.svg")),
+      light: vscode.Uri.file(getIconPath("light/issues.svg")),
     });
 
     node.id = "5";
@@ -142,14 +127,13 @@ export class HelpsTreeItem extends AzExtParentTreeItem {
     return node;
   }
 
-  private get reportIssuesTreeItem(): AzExtTreeItem {
+  private get reportIssuesTreeItem(): vscode.TreeItem {
     const node = new OpenUrlTreeItem(
-      this,
       l10n.t("Report Issue"),
       REPORT_ISSUE_URL,
       {
-        dark: getIconPath("dark/comment.svg"),
-        light: getIconPath("light/comment.svg"),
+        dark: vscode.Uri.file(getIconPath("dark/comment.svg")),
+        light: vscode.Uri.file(getIconPath("light/comment.svg")),
       }
     );
     node.id = "6";

--- a/src/views/tree.views/NativeTreeDataProvider.ts
+++ b/src/views/tree.views/NativeTreeDataProvider.ts
@@ -1,0 +1,27 @@
+import * as vscode from 'vscode';
+
+export interface INativeTreeItem extends vscode.TreeItem {
+	getChildren?(): Promise<vscode.TreeItem[]>;
+}
+
+export class NativeTreeDataProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+	private _onDidChangeTreeData: vscode.EventEmitter<vscode.TreeItem | undefined | null> = new vscode.EventEmitter<vscode.TreeItem | undefined | null>();
+	readonly onDidChangeTreeData: vscode.Event<vscode.TreeItem | undefined | null> = this._onDidChangeTreeData.event;
+
+	constructor(private readonly root: INativeTreeItem) {}
+
+	refresh(): void {
+		this._onDidChangeTreeData.fire(undefined);
+	}
+
+	getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
+		return element;
+	}
+
+	async getChildren(element?: INativeTreeItem): Promise<vscode.TreeItem[]> {
+		if (!element) {
+			return this.root.getChildren ? this.root.getChildren() : [];
+		}
+		return element.getChildren ? element.getChildren() : [];
+	}
+}

--- a/src/views/tree.views/OpenUrlTreeItem.ts
+++ b/src/views/tree.views/OpenUrlTreeItem.ts
@@ -1,26 +1,22 @@
 import * as vscode from "vscode";
 
-import {
-  AzExtParentTreeItem,
-  GenericTreeItem,
-} from "@microsoft/vscode-azext-utils";
 
-export class OpenUrlTreeItem extends GenericTreeItem {
+export class OpenUrlTreeItem extends vscode.TreeItem {
   private _url: string;
 
   public constructor(
-    parent: AzExtParentTreeItem,
     label: string,
     url: string,
-    iconPath?: vscode.ThemeIcon
+    iconPath?: vscode.ThemeIcon | { dark: vscode.Uri; light: vscode.Uri }
   ) {
-    super(parent, {
-      commandId: "metacall.openUrl",
-      contextValue: "openUrl",
-      iconPath: iconPath,
-      includeInTreeItemPicker: true,
-      label,
-    });
+    super(label, vscode.TreeItemCollapsibleState.None);
+    this.command = {
+      command: "metacall.openUrl",
+      title: "Open URL",
+      arguments: [this],
+    };
+    this.contextValue = "openUrl";
+    this.iconPath = iconPath;
     this._url = url;
   }
 

--- a/src/views/tree.views/home.tree.item.ts
+++ b/src/views/tree.views/home.tree.item.ts
@@ -1,18 +1,19 @@
-import {
-  AzExtParentTreeItem,
-  AzExtTreeItem,
-  GenericTreeItem,
-} from "@microsoft/vscode-azext-utils";
+import * as vscode from "vscode";
 import { l10n } from "vscode";
 import { getIconPath } from "../../utils/utilities";
 
-export class HomeTreeItem extends AzExtParentTreeItem {
+export class HomeTreeItem extends vscode.TreeItem {
   public label: string = "Home";
   public contextValue: string = "home";
 
-  private values?: GenericTreeItem[];
+  constructor() {
+    super("Home", vscode.TreeItemCollapsibleState.Expanded);
+    this.contextValue = "home";
+  }
 
-  public async loadMoreChildrenImpl(): Promise<AzExtTreeItem[]> {
+  private values?: vscode.TreeItem[];
+
+  public async getChildren(): Promise<vscode.TreeItem[]> {
     return (
       this.values ??
       (this.values = [
@@ -23,66 +24,60 @@ export class HomeTreeItem extends AzExtParentTreeItem {
     );
   }
 
-  public hasMoreChildrenImpl(): boolean {
-    return false;
-  }
-
-  public compareChildrenImpl(
-    item1: AzExtTreeItem,
-    item2: AzExtTreeItem
-  ): number {
-    if (!item1 || !item1.id) {
-      return -1;
-    }
-    if (!item2 || !item2.id) {
-      return 1;
-    }
-    return item1?.id.localeCompare(item2?.id);
-  }
-
-  private get deployWithRepoUrlTreeItem(): AzExtTreeItem {
-    const node = new GenericTreeItem(this, {
-      label: l10n.t("Deploy with Repository URL"),
-      contextValue: "Deploy with Repository URL",
-      commandId: "metacall.deployWithRepoUrl",
-      iconPath: {
-        dark: getIconPath("dark/link.svg"),
-        light: getIconPath("light/link.svg"),
-      },
-      includeInTreeItemPicker: true,
-    });
-
+  private get deployWithRepoUrlTreeItem(): vscode.TreeItem {
+    const node = new vscode.TreeItem(
+      l10n.t("Deploy with Repository URL"),
+      vscode.TreeItemCollapsibleState.None
+    );
+    node.contextValue = "Deploy with Repository URL";
+    node.command = {
+      command: "metacall.deployWithRepoUrl",
+      title: l10n.t("Deploy with Repository URL"),
+      arguments: [node],
+    };
+    node.iconPath = {
+      dark: vscode.Uri.file(getIconPath("dark/link.svg")),
+      light: vscode.Uri.file(getIconPath("light/link.svg")),
+    };
     node.id = "0";
 
     return node;
   }
 
-  private get inspectTreeItem(): AzExtTreeItem {
-    const node = new GenericTreeItem(this, {
-      label: l10n.t("Inspect Deployed Applications"),
-      contextValue: "Inspect",
-      commandId: "metacall.inspect",
-      iconPath: {
-        dark: getIconPath("dark/inspect.svg"),
-        light: getIconPath("light/inspect.svg"),
-      },
-      includeInTreeItemPicker: true,
-    });
+  private get inspectTreeItem(): vscode.TreeItem {
+    const node = new vscode.TreeItem(
+      l10n.t("Inspect Deployed Applications"),
+      vscode.TreeItemCollapsibleState.None
+    );
+    node.contextValue = "Inspect";
+    node.command = {
+      command: "metacall.inspect",
+      title: l10n.t("Inspect Deployed Applications"),
+      arguments: [node],
+    };
+    node.iconPath = {
+      dark: vscode.Uri.file(getIconPath("dark/inspect.svg")),
+      light: vscode.Uri.file(getIconPath("light/inspect.svg")),
+    };
     node.id = "1";
     return node;
   }
 
-  private get deleteDeploymentTreeItem(): AzExtTreeItem {
-    const node = new GenericTreeItem(this, {
-      label: l10n.t("Delete Deployed Applications"),
-      contextValue: "Delete",
-      commandId: "metacall.deleteDeployment",
-      iconPath: {
-        dark: getIconPath("dark/trash.svg"),
-        light: getIconPath("light/trash.svg"),
-      },
-      includeInTreeItemPicker: true,
-    });
+  private get deleteDeploymentTreeItem(): vscode.TreeItem {
+    const node = new vscode.TreeItem(
+      l10n.t("Delete Deployed Applications"),
+      vscode.TreeItemCollapsibleState.None
+    );
+    node.contextValue = "Delete";
+    node.command = {
+      command: "metacall.deleteDeployment",
+      title: l10n.t("Delete Deployed Applications"),
+      arguments: [node],
+    };
+    node.iconPath = {
+      dark: vscode.Uri.file(getIconPath("dark/trash.svg")),
+      light: vscode.Uri.file(getIconPath("light/trash.svg")),
+    };
     node.id = "2";
     return node;
   }


### PR DESCRIPTION
## Summary
Removes the `@microsoft/vscode-azext-utils` dependency and replaces all usage with native VS Code APIs, eliminating the Microsoft telemetry warning flagged in #32.

## Problem
`@microsoft/vscode-azext-utils` pulls in `applicationinsights-native-metrics` which collects Microsoft telemetry. This caused a warning in CI and is unnecessary for a lightweight deploy extension.

## Changes
- Removed `@microsoft/vscode-azext-utils` and `@microsoft/vscode-azureresources-api` from dependencies
- Created `NativeTreeDataProvider.ts` implementing `vscode.TreeDataProvider` natively
- Replaced `AzExtParentTreeItem` and `AzExtTreeItem` with `vscode.TreeItem`
- Replaced `GenericTreeItem` with native `vscode.TreeItem`
- Updated all 5 affected files

## Result
- Zero TypeScript compilation errors
- No Microsoft telemetry
- No functionality changes — all labels, icons, and commands preserved

## Type of change
- [x] Bug fix (removes telemetry warning)

## Checklist
- [x] I have read the contributing guidelines
- [x] My changes generate no new warnings